### PR TITLE
Removing Json.NET dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ To include kongregate-web as a Unity package, you'll need to be on Unity 2018.3 
 
 To use kongregate-web, you'll first need to include the Kongregate JavaScript API in your build's generated `index.html` file. To do so, follow the Unity instructions for [setting up a custom WebGL template](https://docs.unity3d.com/Manual/webgl-templates.html), then add a link to `kongregate_api.js` as described in the [Kongregate JavaScript guide](https://docs.kongregate.com/docs/javascript-api#section-loading-the-api).
 
-> NOTE: There's an additional dependency on [Json.NET](https://www.newtonsoft.com/json) currently, which means you'll need to import it into your project in order to use kongregate-web. There is a [package on the Unity store](https://assetstore.unity.com/packages/tools/input-management/json-net-for-unity-11347) that you can use for this purpose. This dependency will be removed in a future version, see [#1](https://github.com/randomPoison/kongregate-web/issues/1).
-
 ## Usage
 
 The API is accessible through public, static methods on the `KongregateWeb` class. You never need to access the `KongregateWeb` instance directly.

--- a/Runtime/KongregateStoreItem.cs
+++ b/Runtime/KongregateStoreItem.cs
@@ -2,12 +2,32 @@ namespace Kongregate.Web {
     [Serializable]
     public class KongregateStoreItem
     {
-        public readonly int id;
-        public readonly string identifier;
-        public readonly string name;
-        public readonly string description;
-        public readonly int price;
-        public readonly string[] tags;
-        public readonly string image_url;
+        [SerializeField]
+        private readonly int id;
+        public readonly int Id => id;
+
+        [SerializeField]
+        private readonly string identifier;
+        public readonly string Identifier => identifier;
+
+        [SerializeField]
+        private readonly string name;
+        public readonly string Name => name;
+
+        [SerializeField]
+        private readonly string description;
+        public readonly string Description => description;
+
+        [SerializeField]
+        private readonly int price;
+        public readonly int Price => price;
+
+        [SerializeField]
+        private readonly string[] tags;
+        public readonly string[] Tags => tags;
+
+        [SerializeField]
+        private readonly string image_url;
+        public readonly string ImageUrl => image_url;
     }
 }

--- a/Runtime/KongregateStoreItem.cs
+++ b/Runtime/KongregateStoreItem.cs
@@ -1,27 +1,13 @@
-using Newtonsoft.Json;
-
 namespace Kongregate.Web {
+    [Serializable]
     public class KongregateStoreItem
     {
-        [JsonProperty("id")]
-        public readonly int Id;
-
-        [JsonProperty("identifier")]
-        public readonly string Identifier;
-
-        [JsonProperty("name")]
-        public readonly string Name;
-
-        [JsonProperty("description")]
-        public readonly string Description;
-
-        [JsonProperty("price")]
-        public readonly int Price;
-
-        [JsonProperty("tags")]
-        public readonly string[] Tags;
-
-        [JsonProperty("image_url")]
-        public readonly string ImageUrl;
+        public readonly int id;
+        public readonly string identifier;
+        public readonly string name;
+        public readonly string description;
+        public readonly int price;
+        public readonly string[] tags;
+        public readonly string image_url;
     }
 }

--- a/Runtime/KongregateUserItem.cs
+++ b/Runtime/KongregateUserItem.cs
@@ -1,18 +1,10 @@
-using Newtonsoft.Json;
-
 namespace Kongregate.Web {
+    [Serializable]
     public class KongregateUserItem
     {
-        [JsonProperty("id")]
-        public readonly int Id;
-
-        [JsonProperty("identifier")]
-        public readonly string Identifier;
-
-        [JsonProperty("data")]
-        public readonly string Data;
-
-        [JsonProperty("remaining_uses")]
-        public readonly int RemainingUses;
+        public readonly int id;
+        public readonly string identifier;
+        public readonly string data;
+        public readonly int remaining_uses;
     }
 }

--- a/Runtime/KongregateUserItem.cs
+++ b/Runtime/KongregateUserItem.cs
@@ -1,10 +1,21 @@
 namespace Kongregate.Web {
-    [Serializable]
+[Serializable]
     public class KongregateUserItem
     {
-        public readonly int id;
-        public readonly string identifier;
-        public readonly string data;
-        public readonly int remaining_uses;
+        [SerializeField]
+        private readonly int id;
+        public readonly int Id => id;
+
+        [SerializeField]         
+        private readonly string identifier;
+        public readonly string Identifier => identifier;
+
+        [SerializeField]
+        private readonly string data;
+        public readonly string Data => data;
+
+        [SerializeField]
+        private readonly int remaining_uses;
+        public readonly int RemainingUses => remaining_uses;
     }
 }

--- a/Runtime/KongregateWeb.cs
+++ b/Runtime/KongregateWeb.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using Newtonsoft.Json;
 using UnityEngine;
 
 namespace Kongregate.Web
@@ -310,13 +309,13 @@ namespace Kongregate.Web
         public static void PurchaseItems(string[] items)
         {
             AssertIsReady();
-            purchaseItems(JsonConvert.SerializeObject(items));
+            purchaseItems(JsonUtility.ToJson(items));
         }
 
         public static void RequestItemList(string[] tags = null)
         {
             AssertIsReady();
-            requestItemList(tags != null ? JsonConvert.SerializeObject(tags) : null);
+            requestItemList(tags != null ? JsonUtility.ToJson(tags) : null);
         }
 
         public static void RequestUserItemList(string username = null)
@@ -428,25 +427,25 @@ namespace Kongregate.Web
 
         private void OnPurchaseItemsSucceeded(string itemsJSON)
         {
-            var items = JsonConvert.DeserializeObject<string[]>(itemsJSON);
+            var items = JsonUtility.FromJson<string[]>(itemsJSON);
             _onPurchaseSucceeded?.Invoke(items);
         }
 
         private void OnPurchaseItemsFailed(string itemsJSON)
         {
-            var items = JsonConvert.DeserializeObject<string[]>(itemsJSON);
+            var items = JsonUtility.FromJson<string[]>(itemsJSON);
             _onPurchaseFailed?.Invoke(items);
         }
 
         private void OnItemList(string itemJSON)
         {
-            var items = JsonConvert.DeserializeObject<KongregateStoreItem[]>(itemJSON);
+            var items = JsonUtility.FromJson<KongregateStoreItem[]>(itemJSON);
             _onItemsReceived?.Invoke(items);
         }
 
         private void OnUserItems(string itemJSON)
         {
-            var items = JsonConvert.DeserializeObject<KongregateUserItem[]>(itemJSON);
+            var items = JsonUtility.FromJson<KongregateUserItem[]>(itemJSON);
             _onUserItemsReceived?.Invoke(items);
         }
 


### PR DESCRIPTION
I had a bit of concern regarding the JsonProperty attributes used with Json.NET, so to maintain compatibility with the JSON fields, I snake cased the properties on the serializable fields to maintain consistency.